### PR TITLE
Updated readme and more version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ The vars for building the deb packages are in `ansible/build-deb-pkgs.yml`
 * The naming convention for the file name in the url did not change. If it did update `download_name`
 * The naming convention for the OSSEC archive did not change. If it did update `archive_name`
 
+### Update version in control files
+
+The `ossec-server` and `ossec-agent` control files and changelog are not currently managed my ansible. They currently require maually changing for each release. This will be fixed in a future release.
+
+Versions need to be updated in
+* `ossec-agent/DEBIAN/control`
+* `ossec-server/DEBIAN/control`
+
+The changelogs need to be updated:
+* `ossec-server/usr/share/doc/ossec-server/changelog.Debian`
+* `ossec-agent/usr/share/doc/ossec-agent/changelog.Debian`
+
 ### Example
 For OSSEC version 2.8.2 updated and verified these values in `ansible/build-deb-pkgs.yml`
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The vars for building the deb packages are in `ansible/build-deb-pkgs.yml`
 
 ### Update version in control files
 
-The `ossec-server` and `ossec-agent` control files and changelog are not currently managed my ansible. They currently require maually changing for each release. This will be fixed in a future release.
+The `ossec-server` and `ossec-agent` control files and changelog are not currently managed by ansible. They currently require maually changing for each release. This will be fixed in a future release.
 
 Versions need to be updated in
 * `ossec-agent/DEBIAN/control`

--- a/ossec-agent/DEBIAN/control
+++ b/ossec-agent/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Homepage: http://ossec.net
 Package: ossec-agent
-Version: 2.8.1
+Version: 2.8.2
 Architecture: amd64
 Depends: libc6,libssl1.0.0,expect,inotify-tools,adduser
 Conflicts: ossec-server

--- a/ossec-agent/etc/ossec-init.conf
+++ b/ossec-agent/etc/ossec-init.conf
@@ -1,4 +1,4 @@
 DIRECTORY="/var/ossec"
-VERSION="v2.8"
-DATE="Sun Sep 28 06:43:55 UTC 2014"
+VERSION="v2.8.2"
+DATE="Thu Jun 11 11:39:25 PDT 2015"
 TYPE="agent"

--- a/ossec-agent/usr/share/doc/ossec-agent/changelog.Debian
+++ b/ossec-agent/usr/share/doc/ossec-agent/changelog.Debian
@@ -1,5 +1,13 @@
+ossec-agent (2.8.2) unstable; urgency=low
+
+  [ SecureDrop Team ]
+  * Release Notes https://github.com/ossec/ossec-hids/releases/tag/2.8.2
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 11 Jun 2015 16:43:47 -0700
+
 ossec-agent (2.8.1) unstable; urgency=low
 
+  [ James Dolan ]
   * Initial release 
 
  -- James Dolan <securedrop@pressfreedomfoundation.org>  Fri, 14 Mar 2014 15:46:57 -0700

--- a/ossec-server/DEBIAN/control
+++ b/ossec-server/DEBIAN/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: SecureDrop Team <securedrop@freedom.press>
 Homepage: http://ossec.net
 Package: ossec-server
-Version: 2.8.1
+Version: 2.8.2
 Architecture: amd64
 Depends: libc6,libssl1.0.0,adduser,expect,libc6 (>= 2.7),inotify-tools
 Conflicts: ossec-agent

--- a/ossec-server/etc/ossec-init.conf
+++ b/ossec-server/etc/ossec-init.conf
@@ -1,4 +1,4 @@
 DIRECTORY="/var/ossec"
-VERSION="v2.7.1"
-DATE="Wed Mar 26 02:15:59 UTC 2014"
+VERSION="v2.8.2"
+DATE="Thu Jun 11 11:39:25 PDT 2015"
 TYPE="server"

--- a/ossec-server/usr/share/doc/ossec-server/changelog.Debian
+++ b/ossec-server/usr/share/doc/ossec-server/changelog.Debian
@@ -1,3 +1,10 @@
+ossec-server (2.8.2) unstable; urgency=low
+
+  [ SecureDrop Team ]
+  * Release Notes https://github.com/ossec/ossec-hids/releases/tag/2.8.2
+
+ -- SecureDrop Team <securedrop@freedom.press>  Thu, 11 Jun 2015 16:43:47 -0700
+
 ossec-server (0.2.1-1) unstable; urgency=low
 
   * Initial release


### PR DESCRIPTION
Updated the readme adding directions for updating some files not managed by ansible.

Updated the files not managed by ansible with new version numbers and timestamps.

Updated the changelog with info from upstream release notes.

Updating the changelog is currently a manual process until the playbook is updated.
