### PR TITLE
Tweaks needed to build packages on remote server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,8 @@
 Vagrant.configure("2") do |config|
 
   config.vm.define 'build' do |build|
-    build.vm.box = "build"
-    build.vm.box = "trusty64"
-    build.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    build.vm.hostname = "build"
+    build.vm.box = "bento/ubuntu-14.04"
     build.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/build-deb-pkgs.yml"
       ansible.verbose = 'v'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,9 @@ Vagrant.configure("2") do |config|
     build.vm.provider "virtualbox" do |v|
       v.name = "ossec-build"
     end
+    build.vm.provider "libvirt" do |lv, override|
+      lv.memory = 1024
+      override.vm.synced_folder './', '/vagrant', type: 'nfs', disabled: false
+    end
   end
-
 end

--- a/ansible/build-deb-pkgs.yml
+++ b/ansible/build-deb-pkgs.yml
@@ -11,6 +11,7 @@
     repo_src_path: "/vagrant"
     arch: "amd64"
     ossec_build_dir: "ossec-{{ purpose }}-{{ ossec_version }}-{{ arch }}"
+    local_build_path: ""
     build_ossec_deb_pkg_dependencies:
       - inotify-tools
       - libssl-dev
@@ -22,4 +23,19 @@
     - { role: build-ossec-deb-pkg, tags: [ "ossec-server" ], purpose: "server" }
     - { role: build-ossec-deb-pkg, tags: [ "ossec-agent" ], purpose: "agent" }
 
+  post_tasks:
+    - name: List debian files in build_dir
+      find:
+        paths: "{{ build_path }}"
+        patterns: "*.deb"
+      register: list_deb_pkgs_results
+      changed_when: false
+
+    - name: Fetch debians if local storage folder provided
+      fetch:
+        src: "{{ item.path }}"
+        dest: "{{ local_build_path }}"
+        flat: yes
+      with_items: "{{ list_deb_pkgs_results.files }}"
+      when: "local_build_path != ''"
   sudo: yes

--- a/ansible/build-deb-pkgs.yml
+++ b/ansible/build-deb-pkgs.yml
@@ -8,6 +8,7 @@
     download_name: "{{ ossec_version }}.tar.gz"
     archive_name: "ossec-hids-{{ download_name }}"
     build_path: "/vagrant/build"
+    repo_src_path: "/vagrant"
     arch: "amd64"
     ossec_build_dir: "ossec-{{ purpose }}-{{ ossec_version }}-{{ arch }}"
     build_ossec_deb_pkg_dependencies:

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -1,4 +1,27 @@
 ---
+# Really this is a check to see if we have to create the repo folder,
+# if thats the case we are not under a local vagrant box with a synced
+# root folder.
+- name: Create src path folder
+  file:
+    state: directory
+    path: "{{ item }}"
+  with_items:
+    - "{{ repo_src_path }}"
+    - "{{ build_path }}"
+  register: ossec_src_path_results
+
+- name: Conditional copy over current directory for repo build
+  synchronize:
+    src: ../../../../
+    dest: "{{ repo_src_path }}"
+    use_ssh_args: yes
+    recursive: yes
+    rsync_opts:
+      - "--exclude=*.git"
+      - "--exclude=*.deb"
+  when: ossec_src_path_results.changed
+
 - name: Include OSSEC download URLs.
   ossec_urls:
     ossec_version: "{{ ossec_version }}"
@@ -80,7 +103,7 @@
   command: cp -R /var/ossec /tmp/{{ ossec_build_dir }}/var/
 
 - name: copy OSSEC DEBIAN dir to build dir
-  command: cp -R /vagrant/ossec-{{ purpose }}/DEBIAN /tmp/{{ ossec_build_dir }}
+  command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/DEBIAN /tmp/{{ ossec_build_dir }}
 
 - name: template the control file
   template:
@@ -88,10 +111,10 @@
     dest: /tmp/{{ ossec_build_dir }}/DEBIAN/control
 
 - name: copy OSSEC usr dir to build dir
-  command: cp -R /vagrant/ossec-{{ purpose }}/usr /tmp/{{ ossec_build_dir }}
+  command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/usr /tmp/{{ ossec_build_dir }}
 
 - name: copy OSSEC etc dir to build dir
-  command: cp -R /vagrant/ossec-{{ purpose }}/etc /tmp/{{ ossec_build_dir }}
+  command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/etc /tmp/{{ ossec_build_dir }}
 
 - name: build securedrop ossec deb package
   command: dpkg-deb --build /tmp/{{ ossec_build_dir }}

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -68,7 +68,7 @@
 
 - name: install deb packages required to build ossec package
   apt: name="{{ item }}" state=latest
-  with_items: build_ossec_deb_pkg_dependencies
+  with_items: "{{ build_ossec_deb_pkg_dependencies }}"
 
 - name: extract OSSEC archive to /tmp
   unarchive:


### PR DESCRIPTION
This is being submoduled into `securedrop` main repo to streamline the package building
process in CI.