### PR TITLE
General config cleanup throughout build logic

### DIFF
--- a/ansible/build-deb-pkgs.yml
+++ b/ansible/build-deb-pkgs.yml
@@ -1,9 +1,14 @@
 ---
-- hosts: [ 'build' ]
+- hosts: build
 
   roles:
-    - { role: build-ossec-deb-pkg, tags: [ "ossec-server" ], purpose: "server" }
-    - { role: build-ossec-deb-pkg, tags: [ "ossec-agent" ], purpose: "agent" }
+    - role: build-ossec-deb-pkg
+      purpose: server
+      tags: ossec-server
+
+    - role: build-ossec-deb-pkg
+      purpose: agent
+      tags: ossec-agent
 
   post_tasks:
     - name: List debian files in build_dir

--- a/ansible/build-deb-pkgs.yml
+++ b/ansible/build-deb-pkgs.yml
@@ -4,13 +4,9 @@
   vars:
     ossec_server_hostname: ossec-server
     ossec_version: 2.8.2
-    download_url: "https://github.com/ossec/ossec-hids/archive"
-    download_name: "{{ ossec_version }}.tar.gz"
-    archive_name: "ossec-hids-{{ download_name }}"
     build_path: "/vagrant/build"
     repo_src_path: "/vagrant"
-    arch: "amd64"
-    ossec_build_dir: "ossec-{{ purpose }}-{{ ossec_version }}-{{ arch }}"
+    ossec_build_dir: "ossec-{{ purpose }}-{{ ossec_version }}-amd64"
     local_build_path: ""
     build_ossec_deb_pkg_dependencies:
       - inotify-tools

--- a/ansible/build-deb-pkgs.yml
+++ b/ansible/build-deb-pkgs.yml
@@ -1,20 +1,6 @@
 ---
 - hosts: [ 'build' ]
 
-  vars:
-    ossec_server_hostname: ossec-server
-    ossec_version: 2.8.2
-    build_path: "/vagrant/build"
-    repo_src_path: "/vagrant"
-    ossec_build_dir: "ossec-{{ purpose }}-{{ ossec_version }}-amd64"
-    local_build_path: ""
-    build_ossec_deb_pkg_dependencies:
-      - inotify-tools
-      - libssl-dev
-      - make
-      - tar
-      - unzip
-
   roles:
     - { role: build-ossec-deb-pkg, tags: [ "ossec-server" ], purpose: "server" }
     - { role: build-ossec-deb-pkg, tags: [ "ossec-agent" ], purpose: "agent" }

--- a/ansible/roles/build-ossec-deb-pkg/defaults/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+build_ossec_deb_pkg_dependencies:
+  - inotify-tools
+  - libssl-dev
+  - make
+  - tar
+  - unzip
+
+ossec_server_hostname: ossec-server
+ossec_version: 2.8.2
+build_path: "/vagrant/build"
+repo_src_path: "/vagrant"
+ossec_build_dir: "ossec-{{ purpose }}-{{ ossec_version }}-amd64"
+local_build_path: ""

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -32,7 +32,9 @@
     dest: "{{ build_path }}/{{ ossec_tarball_filename }}"
 
 - name: Gather checksum info for downloaded tarball.
-  stat: path="{{ build_path }}/{{ ossec_tarball_filename }}" get_md5=yes
+  stat:
+    path: "{{ build_path }}/{{ ossec_tarball_filename }}"
+    get_md5: yes
   register: ossec_download
 
 - name: Fail if MD5 and SHA1 checksums for tarball are not correct.
@@ -54,7 +56,11 @@
              ossec_download.stat.checksum == "{{ ossec_sha1_checksum }}")
 
 - name: install deb packages required to build ossec package
-  apt: name="{{ item }}" state=present update_cache=yes cache_valid_time=3600
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
   with_items: "{{ build_ossec_deb_pkg_dependencies }}"
 
 - name: extract OSSEC archive to /tmp

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -26,9 +26,6 @@
   ossec_urls:
     ossec_version: "{{ ossec_version }}"
 
-- name: apt-get update
-  apt: update_cache=yes
-
 - name: check if ossec was already downloaded
   stat: path="{{ build_path }}/{{ ossec_tarball_filename }}" get_md5=yes
   register: ossec_download
@@ -67,7 +64,7 @@
              ossec_download.stat.checksum == "{{ ossec_sha1_checksum }}")
 
 - name: install deb packages required to build ossec package
-  apt: name="{{ item }}" state=latest
+  apt: name="{{ item }}" state=present update_cache=yes cache_valid_time=3600
   with_items: "{{ build_ossec_deb_pkg_dependencies }}"
 
 - name: extract OSSEC archive to /tmp

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -26,22 +26,12 @@
   ossec_urls:
     ossec_version: "{{ ossec_version }}"
 
-- name: check if ossec was already downloaded
-  stat: path="{{ build_path }}/{{ ossec_tarball_filename }}" get_md5=yes
-  register: ossec_download
-
-- debug: msg="OSSEC download exists will skip downloading again"
-  when: ossec_download.stat.exists
-
-- name: download OSSEC
+- name: Download OSSEC tarball.
   get_url:
     url: "{{ ossec_tarball_url }}"
     dest: "{{ build_path }}/{{ ossec_tarball_filename }}"
-  when: not (ossec_download.stat.exists and
-             ossec_download.stat.md5 == "{{ ossec_md5_checksum }}" and
-             ossec_download.stat.checksum == "{{ ossec_sha1_checksum }}")
 
-- name: check if ossec was already downloaded
+- name: Gather checksum info for downloaded tarball.
   stat: path="{{ build_path }}/{{ ossec_tarball_filename }}" get_md5=yes
   register: ossec_download
 

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -55,7 +55,7 @@
              ossec_download.stat.md5 == "{{ ossec_md5_checksum }}" and
              ossec_download.stat.checksum == "{{ ossec_sha1_checksum }}")
 
-- name: install deb packages required to build ossec package
+- name: Install apt dependencies for building OSSEC packages.
   apt:
     name: "{{ item }}"
     state: present
@@ -63,56 +63,54 @@
     cache_valid_time: 3600
   with_items: "{{ build_ossec_deb_pkg_dependencies }}"
 
-- name: extract OSSEC archive to /tmp
+- name: Extract OSSEC source tarball.
   unarchive:
     copy: no
     src: "{{ build_path }}/{{ ossec_tarball_filename }}"
     dest: /tmp
 
-- name: ensure ossec /etc dir exists
+- name: Create /etc directory within source directory.
   file:
     state: directory
     dest: /tmp/ossec-hids-{{ ossec_version }}/etc
 
-- name: copy ossec preloaded vars
+- name: Copy OSSEC preloaded vars template.
   template:
     src: "{{ purpose }}-preloaded-vars.conf"
     dest: /tmp/ossec-hids-{{ ossec_version }}/etc/preloaded-vars.conf
 
-- name: run ossec installer
+- name: Run OSSEC installer script on extracted source.
   command: /tmp/ossec-hids-{{ ossec_version }}/install.sh
 
-- name: create ossec agent deb build dir
+- name: Create OSSEC build directory.
   file:
     state: directory
-    dest: /tmp/{{ ossec_build_dir }}
+    dest: "{{ item }}"
+  with_items:
+    - /tmp/{{ ossec_build_dir }}
+    - /tmp/{{ ossec_build_dir }}/var
 
-- name: ensure the temp ossec build dir var directory exists
-  file:
-    state: directory
-    dest: /tmp/{{ ossec_build_dir }}/var
-
-- name: mv /var/ossec to ossec build dir
+- name: Copy /var/ossec/ to OSSEC build directory.
   command: cp -R /var/ossec /tmp/{{ ossec_build_dir }}/var/
 
-- name: copy OSSEC DEBIAN dir to build dir
+- name: Copy OSSEC DEBIAN package scripts to build directory.
   command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/DEBIAN /tmp/{{ ossec_build_dir }}
 
-- name: template the control file
+- name: Copy OSEC DEBIAN/control template to build directory.
   template:
     src: "{{ purpose }}_control.j2"
     dest: /tmp/{{ ossec_build_dir }}/DEBIAN/control
 
-- name: copy OSSEC usr dir to build dir
-  command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/usr /tmp/{{ ossec_build_dir }}
+- name: Copy OSSEC /usr and /etc directories to build directory.
+  command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/{{ item }} /tmp/{{ ossec_build_dir }}
+  with_items:
+    - etc
+    - usr
 
-- name: copy OSSEC etc dir to build dir
-  command: cp -R {{ repo_src_path }}/ossec-{{ purpose }}/etc /tmp/{{ ossec_build_dir }}
-
-- name: build securedrop ossec deb package
+- name: Build SecureDrop OSSEC deb package.
   command: dpkg-deb --build /tmp/{{ ossec_build_dir }}
 
-- name: move securedrop ossec deb to repo
+- name: Move SecureDrop OSSEC deb package to repo to output directory.
   command: mv /tmp/{{ ossec_build_dir }}.deb {{ build_path }}
 
 # Running the `install.sh` script shipped with the OSSEC tarball populates the

--- a/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
+++ b/ansible/roles/build-ossec-deb-pkg/tasks/main.yml
@@ -109,27 +109,17 @@
 - name: move securedrop ossec deb to repo
   command: mv /tmp/{{ ossec_build_dir }}.deb {{ build_path }}
 
-- name: delete tmp build paths
+# Running the `install.sh` script shipped with the OSSEC tarball populates the
+# build system with files that should only be included in the deb package.
+# Let's clean up at the end of the build, to prevent these files from being
+# included in the deb package for another purpose (i.e. agent vs. server).
+- name: Delete OSSEC build directories and config files.
   file:
     state: absent
-    dest: /tmp/{{ ossec_build_dir }}
-
-- name: delete tmp install paths
-  file:
-    state: absent
-    dest: /tmp/ossec-hids-{{ ossec_version }}
-
-- name: delete ossec install directory
-  file:
-    state: absent
-    dest: /var/ossec
-
-- name: delete ossec init conf file
-  file:
-    state: absent
-    dest: /etc/ossec-init.conf
-
-- name: delete init script
-  file:
-    state: absent
-    dest: /etc/init.d/ossec
+    dest: "{{ item }}"
+  with_items:
+    - /etc/init.d/ossec
+    - /etc/ossec-init.conf
+    - /tmp/ossec-hids-{{ ossec_version }}
+    - /tmp/{{ ossec_build_dir }}
+    - /var/ossec


### PR DESCRIPTION
Updates the formatting within the dedicated OSSEC build role to make the task list more readable, intuitive, and DRY. **Does not affect build functionality.** All the changes here are cosmetic, intended to match the formatting best practices already implemented in the freedomofpress/securedrop repository, in preparation for merging this repo into that one (https://github.com/freedomofpress/securedrop/issues/1468). 

One change not included here is namespacing of the role default vars; something like `securedrop_build_ossec` seems appropriate, but that can be handled during repo merge. 